### PR TITLE
DB Date-Types erlauben

### DIFF
--- a/plugins/bootstrap-datetimepicker/assets/bootstrap-datetimepicker/bootstrap-datetimepicker.js
+++ b/plugins/bootstrap-datetimepicker/assets/bootstrap-datetimepicker/bootstrap-datetimepicker.js
@@ -4,7 +4,8 @@ $(document).on('ready pjax:success',function() {
     });
     $('.datepicker').datetimepicker({
         locale: 'de',
-        format: 'DD.MM.YYYY'
+        format: 'DD.MM.YYYY',
+        extraFormats: ['YYYY-MM-DD']
     });
     $('.timepicker').datetimepicker({
         locale: 'de',


### PR DESCRIPTION
Somit kann das Plugin auch DB Date-Types verstehen und trotzdem im gewünschten Format anzeigen lassen.
Übrigens, wäre schlau wenn man die Optionen im Addon ändern könnte. Je nachdem möchte ich ein anderes Datumsformat verändern und die Einstellung beim Update des Addons nicht verlieren.